### PR TITLE
Update requestDevice example

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -145,18 +145,21 @@ Devices are not accessible through {{HID/getDevices()}} and will not generate co
   requestButton.addEventListener('click', async () => {
     let device;
     try {
-      device = await navigator.hid.requestDevice({ filters: [{
+      const devices = await navigator.hid.requestDevice({ filters: [{
           vendorId: 0xABCD,
           productId: 0x1234,
           usagePage: 0x0C,
           usage: 0x01
       }]});
+      device = devices[0];
     } catch (error) {
-      console.log('No device was selected.');
+      console.log('An error occured.');
     }
 
     if (device !== undefined) {
       console.log('HID: ${device.productName}');
+    } else {
+      console.log('No device was selected.');
     }
   });
 </pre>


### PR DESCRIPTION
This PR makes sure the example uses a list for `requestDevice`.

From what I've read in https://github.com/WICG/webhid/issues/3, I also believe this method should be renamed to `requestDevices` to prevent web developers confusion.