### PR TITLE
Use byte for unitExponent

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,7 +400,7 @@ enum HIDUnitSystem {
     readonly attribute unsigned long stringMaximum;
     readonly attribute unsigned short reportSize;
     readonly attribute unsigned short reportCount;
-    readonly attribute unsigned long unitExponent;
+    readonly attribute byte unitExponent;
     readonly attribute unsigned long unit;
     readonly attribute long logicalMinimum;
     readonly attribute long logicalMaximum;


### PR DESCRIPTION
Following [chromium implementation](https://source.chromium.org/chromium/chromium/src/+/master:third_party/blink/renderer/modules/hid/hid_report_item.idl;l=73?q=unitExponent%20f:idl&ss=chromium&originalUrl=https:%2F%2Fcs.chromium.org%2F), `unitExponent` should be  defined as `byte` not `unsigned long` anymore.