### PR TITLE
Use [EnforceRange] for reportId

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -117,9 +117,9 @@ interface HIDDevice {
     readonly attribute FrozenArray<HIDCollectionInfo> collections;
     Promise<void> open();
     Promise<void> close();
-    Promise<void> sendReport(octet reportId, BufferSource data);
-    Promise<void> sendFeatureReport(octet reportId, BufferSource data);
-    Promise<DataView> receiveFeatureReport(octet reportId);
+    Promise<void> sendReport([EnforceRange] octet reportId, BufferSource data);
+    Promise<void> sendFeatureReport([EnforceRange] octet reportId, BufferSource data);
+    Promise<DataView> receiveFeatureReport([EnforceRange] octet reportId);
 };
 ```
 

--- a/index.html
+++ b/index.html
@@ -458,9 +458,9 @@ dictionary HIDFieldOptions {
     readonly attribute FrozenArray&lt;HIDCollectionInfo&gt; collections;
     Promise&lt;void&gt; open();
     Promise&lt;void&gt; close();
-    Promise&lt;void&gt; sendReport(octet reportId, BufferSource data);
-    Promise&lt;void&gt; sendFeatureReport(octet reportId, BufferSource data);
-    Promise&lt;DataView&gt; receiveFeatureReport(octet reportId);
+    Promise&lt;void&gt; sendReport([EnforceRange] octet reportId, BufferSource data);
+    Promise&lt;void&gt; sendFeatureReport([EnforceRange] octet reportId, BufferSource data);
+    Promise&lt;DataView&gt; receiveFeatureReport([EnforceRange] octet reportId);
 };
       </pre>
     </section>


### PR DESCRIPTION
This PR makes sure `sendReport()`, `sendFeatureReport()` and `receiveFeatureReport()` will throw an error if an invalid reportId is provided by simply using `EnforceRange`. See https://heycam.github.io/webidl/#EnforceRange

```js
device.sendReport(NaN, Uint8Array.of([42]);
// TypeError: Failed to execute 'sendReport' on 'HIDDevice': Value is not of type 'octet'.
```