### PR TITLE
Fix EXPLAINER link

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         that are not supported by the host's HID driver are inaccessible.
       </p>
       <p>
-        See also the related <a href="EXPLAINER.md">Explainer</a> document.
+        See also the related <a href="EXPLAINER.html">Explainer</a> document.
       </p>
     </section>
     <section id='motivating-applications'>


### PR DESCRIPTION
The EXPLAINER link doesn't work on the GitHub Pages site, it needs to link to `.html`: https://wicg.github.io/webhid/EXPLAINER.html