### PR TITLE
Change some interfaces to dictionaries & Clean

### DIFF
--- a/index.html
+++ b/index.html
@@ -385,60 +385,43 @@ enum HIDUnitSystem {
     "english-rotation", "vendor-defined", "reserved"
 };
 
-[
-    Exposed=Window,
-    SecureContext
-] interface HIDReportItem {
-    readonly attribute boolean isAbsolute;
-    readonly attribute boolean isArray;
-    readonly attribute boolean isRange;
-    readonly attribute boolean hasNull;
-    readonly attribute FrozenArray&lt;unsigned long&gt; usages;
-    readonly attribute unsigned long usageMinimum;
-    readonly attribute unsigned long usageMaximum;
-    readonly attribute unsigned long designatorMinimum;
-    readonly attribute unsigned long designatorMaximum;
-    readonly attribute unsigned long stringMinimum;
-    readonly attribute unsigned long stringMaximum;
-    readonly attribute unsigned short reportSize;
-    readonly attribute unsigned short reportCount;
-    readonly attribute byte unitExponent;
-    readonly attribute unsigned long unit;
-    readonly attribute long logicalMinimum;
-    readonly attribute long logicalMaximum;
-    readonly attribute long physicalMinimum;
-    readonly attribute long physicalMaximum;
+dictionary HIDReportItem {
+    boolean isAbsolute;
+    boolean isArray;
+    boolean isRange;
+    boolean hasNull;
+    sequence&lt;unsigned long&gt; usages;
+    unsigned long usageMinimum;
+    unsigned long usageMaximum;
+    unsigned short reportSize;
+    unsigned short reportCount;
+    byte unitExponent;
+    HIDUnitSystem unitSystem;
+    byte unitFactorLengthExponent;
+    byte unitFactorMassExponent;
+    byte unitFactorTimeExponent;
+    byte unitFactorTemperatureExponent;
+    byte unitFactorCurrentExponent;
+    byte unitFactorLuminousIntensityExponent;
+    long logicalMinimum;
+    long logicalMaximum;
+    long physicalMinimum;
+    long physicalMaximum;
+    sequence&lt;DOMString&gt; strings;
 };
 
-[
-    Exposed=Window,
-    SecureContext
-] interface HIDReportInfo {
-    readonly attribute octet reportId;
-    readonly attribute FrozenArray&lt;HIDReportItem&gt; items;
+dictionary HIDReportInfo {
+    octet reportId;
+    sequence&lt;HIDReportItem&gt; items;
 };
 
-dictionary HIDFieldOptions {
-    required octet reportId;
-    required unsigned long fieldIndex;
-    boolean isFeatureReport;
-};
-
-[
-    Exposed=Window,
-    SecureContext
-] interface HIDCollectionInfo {
-    readonly attribute unsigned short usagePage;
-    readonly attribute unsigned short usage;
-    readonly attribute FrozenArray&lt;HIDCollectionInfo&gt; children;
-    readonly attribute FrozenArray&lt;HIDReportInfo&gt; inputReports;
-    readonly attribute FrozenArray&lt;HIDReportInfo&gt; outputReports;
-    readonly attribute FrozenArray&lt;HIDReportInfo&gt; featureReports;
-    readonly attribute FrozenArray&lt;octet&gt; reportIds;
-
-    double getField(BufferSource reportData, HIDFieldOptions options);
-    void setField(BufferSource reportData, HIDFieldOptions options,
-                  double value);
+dictionary HIDCollectionInfo {
+    unsigned short usagePage;
+    unsigned short usage;
+    sequence&lt;HIDCollectionInfo&gt; children;
+    sequence&lt;HIDReportInfo&gt; inputReports;
+    sequence&lt;HIDReportInfo&gt; outputReports;
+    sequence&lt;HIDReportInfo&gt; featureReports;
 };
         </pre>
       </section>


### PR DESCRIPTION
This PR changes `HIDCollectionInfo`, `HIDReportInfo`, and `HIDReportItem` interfaces to dictionaries for easier logging with JSON and to avoid polluting the window web namespace. FIX #22

Moreover, it removes some elements that are not implemented in Chromium implementation so that web developers interested in reading the spec are not confused:
- Removal of `designatorMinimum`, `designatorMaximum`, `stringMinimum`, `stringMaximum`, `unit` in `HIDReportItem`
- Addition of `unitSystem`, `unitFactorLengthExponent`, `unitFactorMassExponent`, `unitFactorTimeExponent`, `unitFactorTemperatureExponent`, `unitFactorCurrentExponent`, `unitFactorLuminousIntensityExponent` and `strings` in `HIDReportItem`
- Removal of `reportIds`, `getField()`, and `setField()` in `HIDCollectionInfo`

@nondebug Please have a look