### PR TITLE
Updating Jabra block rule

### DIFF
--- a/blocklist.txt
+++ b/blocklist.txt
@@ -30,5 +30,5 @@
   {usagePage:0xF1D0},
   
   // Block Jabra access to certain proprietary functionality. 
-  { vendor:0x0b0e, usagePage:0xff00, reportId:0x05, reportType:"output" },
+  { vendor:0x0b0e, usagePage:0xff00, reportType:"output" },
 ]


### PR DESCRIPTION
Updated to block all outgoing reports for usagePage 0xff00 with no report ID specified.