### PR TITLE
Improve wording in the "matching collection" paragraph.

### DIFF
--- a/index.html
+++ b/index.html
@@ -340,11 +340,11 @@
       </p>
       <ol>
         <li>If |filter|.{{HIDDeviceFilter/usagePage}} is present and
-        |device|.{{HIDCollectionInfo/usagePage}} does not equal
+        |collection|.{{HIDCollectionInfo/usagePage}} does not equal
         |filter|.{{HIDDeviceFilter/usagePage}}, return mismatch.
         </li>
         <li>If |filter|.{{HIDDeviceFilter/usage}} is present and
-        |device|.{{HIDCollectionInfo/usage}} does not equal
+        |collection|.{{HIDCollectionInfo/usage}} does not equal
         |filter|.{{HIDDeviceFilter/usage}}, return mismatch.
         </li>
         <li>Return match.


### PR DESCRIPTION
I found the paragraph about device filtering by collection matching a bit confusing. The problem is that two bullets refer to `device` instead of `collection`. This should improve it.