### PR TITLE
Fix default allowlist

### DIFF
--- a/index.html
+++ b/index.html
@@ -505,7 +505,7 @@
           The feature name for this feature is `"hid"`.
         </p>
         <p>
-          The [=default allowlist=] for this feature is `["self"]`.
+          The [=default allowlist=] for this feature is `'self'`.
         </p>
       </section>
     </section>


### PR DESCRIPTION
The options for default allowlist are `*` or `'self'`.

CC @nondebug 