### PR TITLE
Suppress the "Latest published version"

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     <script class='remove'>
       var respecConfig = {
         specStatus: "CG-DRAFT",
+        latestVersion: null,
         editors: [{
           name: "Matt Reynolds", w3cid: "105511",
           company: "Google", companyURL: "https://www.google.com/"


### PR DESCRIPTION
Since this is a CG-DRAFT there is no previously version to link to. ReSpec will include a broken link to a non-existent TR page if this isn't suppressed.