### PR TITLE
Add exclusionFilters option in requestDevice()

### DIFF
--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -93,7 +93,7 @@ interface HIDInputReportEvent : Event {
 
 dictionary HIDDeviceRequestOptions {
     required sequence<HIDDeviceFilter> filters;
-    sequence<HIDDeviceExclude> excludes = [];
+    sequence<HIDDeviceFilter> exclusionFilters = [];
 };
 
 dictionary HIDDeviceFilter {
@@ -101,11 +101,6 @@ dictionary HIDDeviceFilter {
     unsigned short productId;
     unsigned short usagePage;
     unsigned short usage;
-};
-
-dictionary HIDDeviceExclude {
-    unsigned long vendorId;
-    unsigned short productId;
 };
 ```
 

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -93,6 +93,7 @@ interface HIDInputReportEvent : Event {
 
 dictionary HIDDeviceRequestOptions {
     required sequence<HIDDeviceFilter> filters;
+    sequence<HIDDeviceExclude> excludes = [];
 };
 
 dictionary HIDDeviceFilter {
@@ -100,6 +101,11 @@ dictionary HIDDeviceFilter {
     unsigned short productId;
     unsigned short usagePage;
     unsigned short usage;
+};
+
+dictionary HIDDeviceExclude {
+    unsigned long vendorId;
+    unsigned short productId;
 };
 ```
 

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -93,7 +93,7 @@ interface HIDInputReportEvent : Event {
 
 dictionary HIDDeviceRequestOptions {
     required sequence<HIDDeviceFilter> filters;
-    sequence<HIDDeviceFilter> exclusionFilters = [];
+    sequence<HIDDeviceFilter> exclusionFilters;
 };
 
 dictionary HIDDeviceFilter {

--- a/index.html
+++ b/index.html
@@ -1029,6 +1029,28 @@
               </li>
             </ol>
           </li>
+          <li>If |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"] is
+          present, then run the following steps [=list/for each=]
+          |exclusionFilter:HIDDeviceFilter| of
+          |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"]:
+            <ol>
+              <li>If |exclusionFilter| is empty, then [=reject=] |promise| with
+              a {{TypeError}} and return |promise|.
+              </li>
+              <li>If |exclusionFilter|["{{HIDDeviceFilter/productId}}"] is
+              present and |exclusionFilter|["{{HIDDeviceFilter/vendorId}}"] is
+              not present, [=reject=] |promise| with a {{TypeError}} and return
+              |promise|.
+              </li>
+              <li>If |exclusionFilter|["{{HIDDeviceFilter/usage}}"] is present,
+              [=reject=] |promise| with a {{TypeError}} and return |promise|.
+              </li>
+              <li>If |exclusionFilter|["{{HIDDeviceFilter/usagePage}}"] is
+              present, [=reject=] |promise| with a {{TypeError}} and return
+              |promise|.
+              </li>
+            </ol>
+          </li>
           <li>Run the following steps [=in parallel=]:
             <ol>
               <li>Initialize |availableDevices| to be an empty [=list=].
@@ -1039,8 +1061,8 @@
                   <li>If |device| [=matches any filter=] in
                   |options|["{{HIDDeviceRequestOptions/filters}}"] and [=is not
                   excluded=] in
-                  |options|["{{HIDDeviceRequestOptions/excludes}}"], then
-                  [=list/append=] |device| to |availableDevices|.
+                  |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"],
+                  then [=list/append=] |device| to |availableDevices|.
                   </li>
                 </ol>
               </li>
@@ -1090,7 +1112,7 @@
           <pre class="idl">
             dictionary HIDDeviceRequestOptions {
                 required sequence&lt;HIDDeviceFilter&gt; filters;
-                sequence&lt;HIDDeviceExclude&gt; excludes = [];
+                sequence&lt;HIDDeviceFilter&gt; exclusionFilters = [];
             };
           </pre>
           <dl>
@@ -1101,10 +1123,10 @@
               Filters for HID devices.
             </dd>
             <dt>
-              <dfn>excludes</dfn> member
+              <dfn>exclusionFilters</dfn> member
             </dt>
             <dd>
-              Excludes HID devices.
+              Exclusion filters for HID devices.
             </dd>
           </dl>
         </section>
@@ -1151,12 +1173,12 @@
           </dl>
           <div class="note">
             <p>
-              Device filters are used to narrow the list of devices presented
-              to the user in the chooser dialog created by
-              {{HID/requestDevice()}}. When no filters are provided, all
-              connected devices that don't match any excludes are included. When
-              one or more filters are provided, a device is included if any
-              filter matches and it doesn't match any excludes.
+              Device filters are used to narrow the list of devices presented to
+              the user in the chooser dialog created by {{HID/requestDevice()}}.
+              When no filters are provided, all connected devices matching no
+              exclusion filters are included. When one or more filters are
+              provided, a device is included if any filter matches and no
+              exclusion filters matches.
             </p>
             <p>
               All {{HIDDeviceFilter}} members are optional. Each member
@@ -1193,6 +1215,13 @@
               Device ID rules and usage rules may be combined. For instance, an
               application may want to match devices from a particular vendor,
               but only devices that implement a specific device class.
+            </p>
+            <p>
+              The {{HIDDeviceRequestOptions/exclusionFilters}} option allows an
+              application to exclude some devices presented to the user from the
+              chooser dialog created by {{HID/requestDevice()}} that are known
+              to not work as expected, even though they implement a specific
+              device class for instance.
             </p>
           </div>
           <p>
@@ -1272,55 +1301,22 @@
             <li>Return `true`.
             </li>
           </ol>
-        </section>
-        <section data-dfn-for="HIDDeviceExclude">
-          <h4>
-            <dfn>HIDDeviceExclude</dfn> dictionary
-          </h4>
-          <pre class="idl">
-            dictionary HIDDeviceExclude {
-                unsigned long vendorId;
-                unsigned short productId;
-            };
-          </pre>
-          <dl>
-            <dt>
-              <dfn>vendorId</dfn> member
-            </dt>
-            <dd>
-              The [=vendor ID=] to match.
-            </dd>
-            <dt>
-              <dfn>productId</dfn> member
-            </dt>
-            <dd>
-              The [=product ID=] to match.
-            </dd>
-          </dl>
-          <div class="note">
-            <p>
-              The {{HIDDeviceRequestOptions/excludes}} option allows an
-              application to exclude some devices presented to the user from the
-              chooser dialog created by {{HID/requestDevice()}} that are known
-              to not work as expected, even though they implement a specific
-              device class for instance.
-            </p>
-          </div>
           <p>
-            A {{HIDDevice}} |device:HIDDevice| <dfn>is not excluded</dfn> in
-            a [=sequence=] |excludes:sequence&lt;HIDDeviceExclude&gt;| of
-            {{HIDDeviceExclude}} if these steps return `true`:
+            A {{HIDDevice}} |device:HIDDevice| <dfn>is not excluded</dfn> in a
+            [=sequence=] |exclusionFilters:sequence&lt;HIDDeviceFilter&gt;| of
+            {{HIDDeviceFilter}} if these steps return `true`:
           </p>
           <ol>
-            <li>If |excludes| is empty, then return `true`.
+            <li>If |exclusionFilters| is empty, then return `true`.
             </li>
-            <li>[=list/For each=] |exclude:HIDDeviceExclude| of |excludes|:
+            <li>[=list/For each=] |exclusionFilter:HIDDeviceFilter| of
+            |exclusionFilters|:
               <ol>
-                <li>If |exclude|["{{HIDDeviceExclude/vendorId}}"] is equal to
-                  |device|.{{HIDDevice/vendorId}}, then return `false`.
+                <li>If |exclusionFilter|["{{HIDDeviceFilter/vendorId}}"] is
+                equal to |device|.{{HIDDevice/vendorId}}, then return `false`.
                 </li>
-                <li>If |exclude|["{{HIDDeviceExclude/productId}}"] is equal to
-                  |device|.{{HIDDevice/productId}}, then return `false`.
+                <li>If |exclusionFilter|["{{HIDDeviceFilter/productId}}"] is
+                equal to |device|.{{HIDDevice/productId}}, then return `false`.
                 </li>
               </ol>
             </li>
@@ -2734,8 +2730,9 @@
                     usage: 0x0001,
                   },
                 ],
-                excludes: [
+                exclusionFilters: [
                   {
+                    vendorId: 0xabcd,
                     productId: 0x1234,
                   }
                 ],

--- a/index.html
+++ b/index.html
@@ -1015,39 +1015,27 @@
           then run the following steps [=list/for each=]
           |filter:HIDDeviceFilter| of
           |options|["{{HIDDeviceRequestOptions/filters}}"]:
-            <ol>
-              <li>If |filter| is empty, then [=reject=] |promise| with a
-              {{TypeError}} and return |promise|.
-              </li>
-              <li>If |filter|["{{HIDDeviceFilter/productId}}"] is present and
-              |filter|["{{HIDDeviceFilter/vendorId}}"] is not present,
-              [=reject=] |promise| with a {{TypeError}} and return |promise|.
-              </li>
-              <li>If |filter|["{{HIDDeviceFilter/usage}}"] is present and
-              |filter|["{{HIDDeviceFilter/usagePage}}"] is not present,
-              [=reject=] |promise| with a {{TypeError}} and return |promise|.
-              </li>
-            </ol>
+          <ol>
+            <li>If |filter| is not [=a valid filter=], then [=reject=] |promise|
+            with a {{TypeError}} and return |promise|.
+            </li>
+          </ol>
           </li>
           <li>If |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"] is
-          present, then run the following steps [=list/for each=]
-          |exclusionFilter:HIDDeviceFilter| of
-          |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"]:
+          present, then run the following steps:
             <ol>
-              <li>If |exclusionFilter| is empty, then [=reject=] |promise| with
-              a {{TypeError}} and return |promise|.
-              </li>
-              <li>If |exclusionFilter|["{{HIDDeviceFilter/productId}}"] is
-              present and |exclusionFilter|["{{HIDDeviceFilter/vendorId}}"] is
-              not present, [=reject=] |promise| with a {{TypeError}} and return
+              <li>If |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"] is
+              empty, then [=reject=] |promise| with a {{TypeError}} and return
               |promise|.
               </li>
-              <li>If |exclusionFilter|["{{HIDDeviceFilter/usage}}"] is present,
-              [=reject=] |promise| with a {{TypeError}} and return |promise|.
-              </li>
-              <li>If |exclusionFilter|["{{HIDDeviceFilter/usagePage}}"] is
-              present, [=reject=] |promise| with a {{TypeError}} and return
-              |promise|.
+              <li>[=list/For each=] |exclusionFilter:HIDDeviceFilter| of
+              |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"]:
+                <ol>
+                  <li>If |exclusionFilter| is not [=a valid filter=], then
+                  [=reject=] |promise| with a {{TypeError}} and return
+                  |promise|.
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>
@@ -1059,8 +1047,8 @@
               [=this=].{{HID/[[devices]]}}:
                 <ol>
                   <li>If |device| [=matches any filter=] in
-                  |options|["{{HIDDeviceRequestOptions/filters}}"] and [=is not
-                  excluded=] in
+                  |options|["{{HIDDeviceRequestOptions/filters}}"] and |device|
+                  does not [=match any filter=] in
                   |options|["{{HIDDeviceRequestOptions/exclusionFilters}}"],
                   then [=list/append=] |device| to |availableDevices|.
                   </li>
@@ -1112,7 +1100,7 @@
           <pre class="idl">
             dictionary HIDDeviceRequestOptions {
                 required sequence&lt;HIDDeviceFilter&gt; filters;
-                sequence&lt;HIDDeviceFilter&gt; exclusionFilters = [];
+                sequence&lt;HIDDeviceFilter&gt; exclusionFilters;
             };
           </pre>
           <dl>
@@ -1225,9 +1213,28 @@
             </p>
           </div>
           <p>
-            A {{HIDDevice}} |device:HIDDevice| <dfn>matches any filter</dfn> in
-            a [=sequence=] |filters:sequence&lt;HIDDeviceFilter&gt;| of
-            {{HIDDeviceFilter}} if these steps return `true`:
+            A {{HIDDeviceFilter}} |filter:HIDDeviceFilter| is <dfn>a valid
+            filter</dfn> if these steps return `true`:
+          </p>
+          <ol>
+            <li>If |filter| is empty, then return `false`.
+            </li>
+            <li>If |filter|["{{HIDDeviceFilter/productId}}"] is present and
+            |filter|["{{HIDDeviceFilter/vendorId}}"] is not present, then return
+            `false`.
+            </li>
+            <li>If |filter|["{{HIDDeviceFilter/usage}}"] is present and
+            |filter|["{{HIDDeviceFilter/usagePage}}"] is not present, then
+            return `false`.
+            </li>
+            <li>Return `true`.
+            </li>
+          </ol>
+          <p>
+            A {{HIDDevice}} |device:HIDDevice| <dfn data-lt="match any
+            filter">matches any filter</dfn> in a [=sequence=]
+            |filters:sequence&lt;HIDDeviceFilter&gt;| of {{HIDDeviceFilter}} if
+            these steps return `true`:
           </p>
           <ol>
             <li>If |filters| is empty, then return `true`.
@@ -1295,28 +1302,6 @@
                 <li>If "{{HIDCollectionInfo/usage}}" is in |filter| and
                 |filter|["{{HIDDeviceFilter/usage}}"] is not equal to
                 |collection|.{{HIDCollectionInfo/usage}}, then return `false`.
-                </li>
-              </ol>
-            </li>
-            <li>Return `true`.
-            </li>
-          </ol>
-          <p>
-            A {{HIDDevice}} |device:HIDDevice| <dfn>is not excluded</dfn> in a
-            [=sequence=] |exclusionFilters:sequence&lt;HIDDeviceFilter&gt;| of
-            {{HIDDeviceFilter}} if these steps return `true`:
-          </p>
-          <ol>
-            <li>If |exclusionFilters| is empty, then return `true`.
-            </li>
-            <li>[=list/For each=] |exclusionFilter:HIDDeviceFilter| of
-            |exclusionFilters|:
-              <ol>
-                <li>If |exclusionFilter|["{{HIDDeviceFilter/vendorId}}"] is
-                equal to |device|.{{HIDDevice/vendorId}}, then return `false`.
-                </li>
-                <li>If |exclusionFilter|["{{HIDDeviceFilter/productId}}"] is
-                equal to |device|.{{HIDDevice/productId}}, then return `false`.
                 </li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -1037,7 +1037,9 @@
               [=this=].{{HID/[[devices]]}}:
                 <ol>
                   <li>If |device| [=matches any filter=] in
-                  |options|["{{HIDDeviceRequestOptions/filters}}"], then
+                  |options|["{{HIDDeviceRequestOptions/filters}}"] and [=is not
+                  excluded=] in
+                  |options|["{{HIDDeviceRequestOptions/excludes}}"], then
                   [=list/append=] |device| to |availableDevices|.
                   </li>
                 </ol>
@@ -1088,6 +1090,7 @@
           <pre class="idl">
             dictionary HIDDeviceRequestOptions {
                 required sequence&lt;HIDDeviceFilter&gt; filters;
+                sequence&lt;HIDDeviceExclude&gt; excludes = [];
             };
           </pre>
           <dl>
@@ -1096,6 +1099,12 @@
             </dt>
             <dd>
               Filters for HID devices.
+            </dd>
+            <dt>
+              <dfn>excludes</dfn> member
+            </dt>
+            <dd>
+              Excludes HID devices.
             </dd>
           </dl>
         </section>
@@ -1145,8 +1154,9 @@
               Device filters are used to narrow the list of devices presented
               to the user in the chooser dialog created by
               {{HID/requestDevice()}}. When no filters are provided, all
-              connected devices are included. When one or more filters are
-              provided, a device is included if any filter matches.
+              connected devices that don't match any excludes are included. When
+              one or more filters are provided, a device is included if any
+              filter matches and it doesn't match any excludes.
             </p>
             <p>
               All {{HIDDeviceFilter}} members are optional. Each member
@@ -1256,6 +1266,61 @@
                 <li>If "{{HIDCollectionInfo/usage}}" is in |filter| and
                 |filter|["{{HIDDeviceFilter/usage}}"] is not equal to
                 |collection|.{{HIDCollectionInfo/usage}}, then return `false`.
+                </li>
+              </ol>
+            </li>
+            <li>Return `true`.
+            </li>
+          </ol>
+        </section>
+        <section data-dfn-for="HIDDeviceExclude">
+          <h4>
+            <dfn>HIDDeviceExclude</dfn> dictionary
+          </h4>
+          <pre class="idl">
+            dictionary HIDDeviceExclude {
+                unsigned long vendorId;
+                unsigned short productId;
+            };
+          </pre>
+          <dl>
+            <dt>
+              <dfn>vendorId</dfn> member
+            </dt>
+            <dd>
+              The [=vendor ID=] to match.
+            </dd>
+            <dt>
+              <dfn>productId</dfn> member
+            </dt>
+            <dd>
+              The [=product ID=] to match.
+            </dd>
+          </dl>
+          <div class="note">
+            <p>
+              The {{HIDDeviceRequestOptions/excludes}} option allows an
+              application to exclude some devices presented to the user from the
+              chooser dialog created by {{HID/requestDevice()}} that are known
+              to not work as expected, even though they implement a specific
+              device class for instance.
+            </p>
+          </div>
+          <p>
+            A {{HIDDevice}} |device:HIDDevice| <dfn>is not excluded</dfn> in
+            a [=sequence=] |excludes:sequence&lt;HIDDeviceExclude&gt;| of
+            {{HIDDeviceExclude}} if these steps return `true`:
+          </p>
+          <ol>
+            <li>If |excludes| is empty, then return `true`.
+            </li>
+            <li>[=list/For each=] |exclude:HIDDeviceExclude| of |excludes|:
+              <ol>
+                <li>If |exclude|["{{HIDDeviceExclude/vendorId}}"] is equal to
+                  |device|.{{HIDDevice/vendorId}}, then return `false`.
+                </li>
+                <li>If |exclude|["{{HIDDeviceExclude/productId}}"] is equal to
+                  |device|.{{HIDDevice/productId}}, then return `false`.
                 </li>
               </ol>
             </li>
@@ -2651,9 +2716,10 @@
           generate connection events until permission has been granted to
           access the device. The page may request permission using
           {{HID/requestDevice()}}. In this example, the page requests access to
-          a device with [=vendor ID=] `0xABCD`, [=product ID=] `0x1234`. The
-          device must also have a collection with [=usage page=] Consumer
-          (`0x000C`) and [=usage ID=] Consumer Control (`0x0001`).
+          a device with [=vendor ID=] `0xABCD`. The device must also have a
+          collection with [=usage page=] Consumer (`0x000C`) and [=usage ID=]
+          Consumer Control (`0x0001`). The device with [=product ID=] `0x1234`
+          has been reported as malfunctioning.
         </p>
         <pre class="js">
           let requestButton = document.getElementById("request-hid-device");
@@ -2664,10 +2730,14 @@
                 filters: [
                   {
                     vendorId: 0xabcd,
-                    productId: 0x1234,
                     usagePage: 0x000c,
                     usage: 0x0001,
                   },
+                ],
+                excludes: [
+                  {
+                    productId: 0x1234,
+                  }
                 ],
               });
               device = devices[0];


### PR DESCRIPTION
This PR is about a new `"exclusionFilters"` option in `navigator.hid.requestDevice()` so that developers can exclude from the browser picker some known devices that are known to not work as expected.

Currently, developers let users pick a device, then check against a custom helper function (like deviceIsBlocklisted()) if device is known to be malfunctioning.

```js
// Request access to a device with vendor ID 0xABCD. The device must also have a
// collection with usage page Consumer (0x000C) and usage ID Consumer Control
// (0x0001). The device with product ID 0x1234 has been reported as malfunctioning.
const devices = await navigator.hid.requestDevice({
  filters: [{ vendorId: 0xabcd, usagePage: 0x000c, usage: 0x0001 }],
  exclusionFilters: [{ vendorId: 0xabcd, productId: 0x1234 }],
});
```

Please have a look @nondebug 
