### PR TITLE
Restrict requestDevice() to Window only

### DIFF
--- a/index.html
+++ b/index.html
@@ -290,7 +290,7 @@
             attribute EventHandler onconnect;
             attribute EventHandler ondisconnect;
             Promise&lt;sequence&lt;HIDDevice&gt;&gt; getDevices();
-            Promise&lt;sequence&lt;HIDDevice&gt;&gt; requestDevice(
+            [Exposed=Window] Promise&lt;sequence&lt;HIDDevice&gt;&gt; requestDevice(
                 HIDDeviceRequestOptions options);
         };
       </pre>


### PR DESCRIPTION
This pull request updates the spec to remove requestDevice visibility from service worker scope.